### PR TITLE
Automatically run wasm-opt against our artifacts

### DIFF
--- a/justfile
+++ b/justfile
@@ -25,6 +25,7 @@ build PROJECT='':
     echo "Building ${example}.wasm ..."
     if test -f "Cargo.toml"; then
         cargo build --release --target wasm32-wasi --quiet
+        find target/wasm32-wasi/release/*.wasm | xargs -n1 -I'{}' wasm-opt '{}' -Oz -o '{}'
         cp target/wasm32-wasi/release/*.wasm ../build/
     else
         # If it is not a cargo project, we assume a just build command is provided.


### PR DESCRIPTION
Size of the build directory before this change:
53,020,332

And after:
46,228,961

So, that's 13% across all of the projects (some benefit more than others). It's pretty fast, so it seems worth Just Doing It automatically to me.